### PR TITLE
✨ keystore.properties no longer required

### DIFF
--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.2.0
+VERSION_NAME=2.3.0
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/ackee-gradle-plugin


### PR DESCRIPTION
The keystore.properties file was required, even though it was only used for
release builds. These properties should now be defined in our CI environments
so we don't need to require projects to have this file anymore.