### PR TITLE
🐛 Fix appProperties not being loaded

### DIFF
--- a/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/AckeePluginKotlin.kt
+++ b/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/AckeePluginKotlin.kt
@@ -308,10 +308,11 @@ class AckeePluginKotlin : Plugin<Project> {
         }
     }
 
-    private fun Properties.loadKeystoreProperties(keystorePropertiesFile: File) {
+    private fun Properties.loadKeystoreProperties(keystorePropertiesFile: File): Properties {
         val fileReader = FileReader(keystorePropertiesFile)
         val bufferedReader = BufferedReader(fileReader)
         load(bufferedReader)
+        return this
     }
 
     /**

--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.3.0
+VERSION_NAME=2.3.1
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/ackee-gradle-plugin


### PR DESCRIPTION
loadKeystoreProperties() was moved from an apply block to a method chain but
was not returning itself.