### PR TITLE
Add new execution data path to jacoco task

### DIFF
--- a/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/AckeePluginKotlin.kt
+++ b/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/AckeePluginKotlin.kt
@@ -192,7 +192,7 @@ class AckeePluginKotlin : Plugin<Project> {
             }
 
             /**
-             * App Distribution expects changelog in file `outputs/changelog.txt` where Jenkins store the changelog. If this file does
+             * App Distribution expects changelog in file `outputs/changelog.txt` where CI store the changelog. If this file does
              * not exist upload fails. This task ensures that the file exists
              */
             project.tasks.whenTaskAdded {

--- a/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/CodeCoverage.kt
+++ b/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/CodeCoverage.kt
@@ -23,7 +23,7 @@ fun setupCodeCoverageTasks(project: Project) {
         with(it) {
             plugins.apply("jacoco")
             extensions.configure(JacocoPluginExtension::class.java) {
-                this.toolVersion = "0.8.7"
+                this.toolVersion = "0.8.8"
             }
             tasks.create("jacocoTestReport", JacocoReport::class.java) {
                 group = "Reporting"
@@ -45,7 +45,11 @@ fun setupCodeCoverageTasks(project: Project) {
                 classDirectories.setFrom(files(listOf(kotlinTree, javacTree)))
                 executionData.setFrom(fileTree(mapOf(
                     "dir" to buildDir,
-                    "includes" to listOf("jacoco/test${testVariant.capitalize()}UnitTest.exec", "outputs/code-coverage/connected/*coverage.ec")
+                    "includes" to listOf(
+                        "jacoco/test${testVariant.capitalize()}UnitTest.exec",
+                        "outputs/unit_test_code_coverage/${testVariant}UnitTest/test${testVariant.capitalize()}UnitTest.exec",
+                        "outputs/code-coverage/connected/*coverage.ec"
+                    )
                 )))
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.5.20'
-    ext.android_gradle_plugin_version = '7.0.0'
+    ext.kotlin_version = '1.6.21'
+    ext.android_gradle_plugin_version = '7.2.2'
 
     repositories {
         google()
@@ -12,7 +12,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
     }
 }
 

--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.3.1
+VERSION_NAME=2.3.2
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/ackee-gradle-plugin


### PR DESCRIPTION
Since AGP 7.2 the path where test execution data are stored has changed. This fix includes the new path to the list of execution data directories.