### PR TITLE
🐛 Fix CheckChangelogFileTask

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,15 +7,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.5] - 2023-09-01
+
+### Fixed
+
+- `CheckChangelogFileTask` now supports configuration cache too
+
 ## [3.1.4] - 2023-09-01
+
 ### Changed
+
 - Update all dependencies to the latest where possible
 
 ## [3.1.3] - 2023-07-31
 
 ### Fixed
+
 - Fix external execution to support configuration cache
-- Fix getting AGP tasks 
+- Fix getting AGP tasks
   - Tasks should be configured via `configureEach` instead of using `whenTaskAdded`
 
 ## [3.1.2] - 2023-06-23

--- a/build-gradle-plugin/lib.properties
+++ b/build-gradle-plugin/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.1.4
+VERSION_NAME=3.1.5
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/ackee-gradle-plugin

--- a/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/task/CheckChangelogFileTask.kt
+++ b/build-gradle-plugin/src/main/kotlin/cz/ackee/gradle/task/CheckChangelogFileTask.kt
@@ -2,6 +2,8 @@ package cz.ackee.gradle.task
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
@@ -13,9 +15,12 @@ import java.io.File
  */
 abstract class CheckChangelogFileTask : DefaultTask() {
 
+    @get:InputDirectory
+    abstract val changeLogDirectory: DirectoryProperty
+
     @TaskAction
     fun onTaskExecution() {
-        val file = File("${project.rootDir}/outputs/changelog.txt")
+        val file = File(changeLogDirectory.get().asFile, "changelog.txt")
         if (!file.exists()) {
             file.createNewFile()
         }
@@ -27,6 +32,7 @@ abstract class CheckChangelogFileTask : DefaultTask() {
 
         fun registerTask(project: Project): TaskProvider<CheckChangelogFileTask> {
             return project.tasks.register<CheckChangelogFileTask>(createTaskName()) {
+                changeLogDirectory.set(File("${project.rootDir}/outputs"))
                 group = Groups.DEPLOYMENT
             }
         }


### PR DESCRIPTION
To support configuration cache I cannot access project properties inside task execution. So I moved it into configuration phase. 