### PR TITLE
🐛 Add validation for folder paths in CopyGitHooksTask

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.2] - 2025-09-13
+### Changed
+- Add verification of source and target folders in CopyGitHooksTask and register the task only if both 
+folders exist.
+
 ## [3.3.1] - 2025-09-11
 ### Changed
 - Update all dependencies including old Jacoco version that was problematic since Gradle 9.0.0

--- a/build-gradle-plugin/lib.properties
+++ b/build-gradle-plugin/lib.properties
@@ -1,6 +1,6 @@
 GROUP_ID=io.github.ackeecz
 ARTIFACT_ID=build-gradle-plugin
-VERSION=3.3.1
+VERSION=3.3.2
 POM_NAME=Ackee Gradle Plugin
 POM_DESCRIPTION=Gradle plugin with some useful configuration shared among projects
 POM_URL=https://github.com/AckeeCZ/ackee-gradle-plugin

--- a/build-gradle-plugin/src/main/kotlin/io/github/ackeecz/gradle/plugin/VerificationsPlugin.kt
+++ b/build-gradle-plugin/src/main/kotlin/io/github/ackeecz/gradle/plugin/VerificationsPlugin.kt
@@ -1,11 +1,11 @@
 package io.github.ackeecz.gradle.plugin
 
 import com.android.build.api.dsl.Lint
-import io.github.ackeecz.gradle.util.getApplicationAndroidComponents
 import io.github.ackeecz.gradle.setUpCodeCoverageTasks
 import io.github.ackeecz.gradle.task.FetchDetektConfigTask
 import io.github.ackeecz.gradle.task.copy.githooks.CopyGitHooksTask
 import io.github.ackeecz.gradle.util.assembleTask
+import io.github.ackeecz.gradle.util.getApplicationAndroidComponents
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.io.File
@@ -45,7 +45,7 @@ class VerificationsPlugin : Plugin<Project> {
     }
 
     private fun Project.setUpCopyGitHooks() {
-        val copyGitHooksProvider = CopyGitHooksTask.registerTask(project)
+        val copyGitHooksProvider = CopyGitHooksTask.registerTask(project) ?: return
         project.getApplicationAndroidComponents().onVariants { variant ->
             variant.assembleTask(project) { it.dependsOn(copyGitHooksProvider) }
         }

--- a/build-gradle-plugin/src/main/kotlin/io/github/ackeecz/gradle/task/copy/githooks/CopyGitHooksTask.kt
+++ b/build-gradle-plugin/src/main/kotlin/io/github/ackeecz/gradle/task/copy/githooks/CopyGitHooksTask.kt
@@ -4,16 +4,28 @@ import io.github.ackeecz.gradle.task.Groups
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.configuration.problems.logger
 import org.gradle.kotlin.dsl.register
+import java.io.File
 
 object CopyGitHooksTask {
 
     private const val taskName = "copyGitHooks"
 
-    fun registerTask(project: Project): TaskProvider<Copy> {
+    fun registerTask(project: Project): TaskProvider<Copy>? {
+        val sourceFolderPath = "${project.rootDir}/.githooks"
+        val targetFolderPath = "${project.rootDir}/.git/hooks"
+
+        if (!File(sourceFolderPath).isDirectory ||
+            !File(targetFolderPath).isDirectory
+        ) {
+            logger.warn("Invalid copy git hooks folder paths. Skipping git hooks installation.")
+            return null
+        }
+
         return project.tasks.register<Copy>(taskName) {
-            from("${project.rootDir}/.githooks")
-            into("${project.rootDir}/.git/hooks")
+            from(sourceFolderPath)
+            into(targetFolderPath)
 
             group = Groups.VERIFICATION
         }


### PR DESCRIPTION
Added checks of source and target paths in CopyGitHooks task so it doesn't fail when paths don't exist (e.g. when using worktrees) 